### PR TITLE
Add TypeScript type check on the CI CD

### DIFF
--- a/.github/workflows/frontend-ci.yaml
+++ b/.github/workflows/frontend-ci.yaml
@@ -49,6 +49,10 @@ jobs:
       run: | 
         npm run lint
 
+    - name: Run Type checking
+      run: | 
+        npm run tsc
+
     - name: Run Unit Tests with Vitest and coverage
       run: | 
         npm run ut


### PR DESCRIPTION
Merging https://github.com/abnamro/resc-frontend/pull/8 and rebasing will fix the breaking test. 😎