### PR TITLE
Fix table size stuck to 300px

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resc-frontend",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "ABN AMRO Bank",
   "description": "Repository Scanner Frontend",
   "license": "MIT",

--- a/src/components/Metrics/RuleMetrics.vue
+++ b/src/components/Metrics/RuleMetrics.vue
@@ -35,7 +35,6 @@
       <!-- sticky-header="85vh" -->
       <b-table
         id="rule-metrics-table"
-        :sticky-header="true"
         :no-border-collapse="true"
         :items="ruleList"
         :fields="fields"

--- a/src/components/ScanFindings/HistoryTab.vue
+++ b/src/components/ScanFindings/HistoryTab.vue
@@ -13,7 +13,7 @@
         <!-- sticky-header="230px" -->
         <b-table
           id="audit-history-table"
-            :items="auditList"
+          :items="auditList"
           :fields="fields"
           :current-page="currentPage"
           :per-page="0"

--- a/src/components/ScanFindings/HistoryTab.vue
+++ b/src/components/ScanFindings/HistoryTab.vue
@@ -13,8 +13,7 @@
         <!-- sticky-header="230px" -->
         <b-table
           id="audit-history-table"
-          :sticky-header="true"
-          :items="auditList"
+            :items="auditList"
           :fields="fields"
           :current-page="currentPage"
           :per-page="0"

--- a/src/views/RepositoriesPanel.vue
+++ b/src/views/RepositoriesPanel.vue
@@ -27,7 +27,6 @@
       <!-- @vue-expect-error Typescript does not recognise the proper types for field -->
       <b-table
         id="repositories-table"
-        :sticky-header="true"
         :items="repositoryList"
         :fields="fields"
         :current-page="1"

--- a/src/views/RuleAnalysis.vue
+++ b/src/views/RuleAnalysis.vue
@@ -58,7 +58,6 @@
       <b-table
         ref="auditTable"
         id="rule-analysis-table"
-        :sticky-header="true"
         :items="findingList"
         :fields="fields"
         :current-page="1"

--- a/src/views/RulePacks.vue
+++ b/src/views/RulePacks.vue
@@ -35,7 +35,6 @@
       <b-table
         id="rule-packs-table"
         :items="rulePackList"
-        :sticky-header="true"
         :fields="fields"
         :current-page="1"
         :per-page="0"

--- a/src/views/ScanFindings.vue
+++ b/src/views/ScanFindings.vue
@@ -47,7 +47,6 @@
     <div class="p-3" v-if="hasRecords">
       <b-table
         id="scan-findings-table"
-        :sticky-header="true"
         :items="findingList"
         :fields="fields"
         :current-page="1"


### PR DESCRIPTION
See here: https://github.com/bootstrap-vue-next/bootstrap-vue-next/releases/tag/bootstrapvuenext-v0.17.0

> **BTable:** stickyHeader true causes maxHeight 300px ([de60ce3](https://github.com/bootstrap-vue-next/bootstrap-vue-next/commit/de60ce3cd2bc3ee8768331ae8ce69b2c5f3eed73))